### PR TITLE
Adding copy tag to clipboard to context menu of tree

### DIFF
--- a/Snoop/PropertyGrid2.xaml
+++ b/Snoop/PropertyGrid2.xaml
@@ -59,7 +59,9 @@ All other rights reserved.
 				<Setter Property="Visibility" Value="Collapsed"/>
 				<Setter Property="ToolTip">
 					<Setter.Value>
-						<TextBlock Style="{x:Null}" Text="Scroll mouse wheel here to edit value"/>
+                        <DataTemplate>
+                            <TextBlock Style="{x:Null}" Text="Scroll mouse wheel here to edit value"/>
+                        </DataTemplate>
 					</Setter.Value>
 				</Setter>
 				<Style.Triggers>

--- a/Snoop/SnoopUI.xaml
+++ b/Snoop/SnoopUI.xaml
@@ -176,7 +176,17 @@ All other rights reserved.
 				<SolidColorBrush x:Key="{x:Static SystemColors.ControlBrushKey}" Color="LightBlue"/>
 			</TreeView.Resources>
 
-			<TreeView.ItemContainerStyle>
+            <TreeView.ContextMenu>
+                <ContextMenu>
+                    <MenuItem x:Name="mnuCopyMarkup" Command="{x:Static local:SnoopUI.CopyMarkupCommand}">
+                        <MenuItem.Header>
+                            <TextBlock Text="Copy markup to clipboard"/>
+                        </MenuItem.Header>
+                    </MenuItem>
+                </ContextMenu>
+            </TreeView.ContextMenu>
+
+            <TreeView.ItemContainerStyle>
 				<Style BasedOn="{StaticResource ProperTreeViewItemStyle}" TargetType="{x:Type local:ProperTreeViewItem}">
 					<Setter Property="IsSelected" Value="{Binding IsSelected, Mode=TwoWay}"/>
 					<Setter Property="IsExpanded" Value="{Binding IsExpanded, Mode=TwoWay}"/>


### PR DESCRIPTION
Fairly basic right now, won't do bindings and stuff, but it gets most of the stuff you'd normally use snoop to change, which is what I was after.

Also fixed a bad tooltip set in PropertyGrid2.xaml.  Considering it's just setting text, you probably don't need the textblock / datatemplate unless you want to style that at some point but, I left it for now.
