### PR TITLE
Fix InvalidOperationException when accessing presentationSource.RootV…

### DIFF
--- a/Snoop/SnoopUI.xaml.cs
+++ b/Snoop/SnoopUI.xaml.cs
@@ -196,7 +196,7 @@ namespace Snoop
 			dispatchers.Add(mainDispatcher);
 			foreach (PresentationSource presentationSource in PresentationSource.CurrentSources)
 			{
-                if(!presentationSource.CheckAccess())
+                if(presentationSource.Dispatcher.Thread.IsBackground)
                     continue;
 
 				Visual presentationSourceRootVisual = presentationSource.RootVisual;

--- a/Snoop/SnoopUI.xaml.cs
+++ b/Snoop/SnoopUI.xaml.cs
@@ -196,6 +196,9 @@ namespace Snoop
 			dispatchers.Add(mainDispatcher);
 			foreach (PresentationSource presentationSource in PresentationSource.CurrentSources)
 			{
+                if(!presentationSource.CheckAccess())
+                    continue;
+
 				Visual presentationSourceRootVisual = presentationSource.RootVisual;
 
                 if (!(presentationSourceRootVisual is Window))


### PR DESCRIPTION
In our application we have a class that wraps a RootVisual in a background threads dispatcher. When running snoop we always get an exception window which can be dismissed and Snoop works as expected. This additional check gets rid of the exception message and makes Snoop work as expected.