### PR TITLE
Proposed fix for not being able to type in Snoop window

### DIFF
--- a/Snoop/SnoopUI.xaml.cs
+++ b/Snoop/SnoopUI.xaml.cs
@@ -848,20 +848,19 @@ namespace Snoop
 						break;
 					}
 				}
-
-
-				if (System.Windows.Forms.Application.OpenForms.Count > 0)
-				{
-					// this is windows forms -> wpf interop
-
-					// call ElementHost.EnableModelessKeyboardInterop to allow the Snoop UI window
-					// to receive keyboard messages. if you don't call this method,
-					// you will be unable to edit properties in the property grid for windows forms interop.
-					ElementHost.EnableModelessKeyboardInterop(this);
-				}
 			}
 
-			return foundRoot;
+            if (System.Windows.Forms.Application.OpenForms.Count > 0)
+            {
+                // this is windows forms -> wpf interop
+
+                // call ElementHost.EnableModelessKeyboardInterop to allow the Snoop UI window
+                // to receive keyboard messages. if you don't call this method,
+                // you will be unable to edit properties in the property grid for windows forms interop.
+                ElementHost.EnableModelessKeyboardInterop(this);
+            }
+
+            return foundRoot;
 		}
 
 		private void Load(object newRoot)


### PR DESCRIPTION
Proposed fix for #55 

Moved the if statement containing the call to EnableModelessKeyboardInterop outside of the else. This resolves an issue where it is not possible to type in the snoop window when snooping certain winforms -> wpf interop applications.

P.S. Huge fan of snoop! Thanks!