### PR TITLE
Added behaviors tab

### DIFF
--- a/Snoop.Core/BehaviorsTab/BehaviorsView.xaml
+++ b/Snoop.Core/BehaviorsTab/BehaviorsView.xaml
@@ -1,0 +1,30 @@
+﻿<Grid x:Class="Snoop.BehaviorsTab.BehaviorsView"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+      xmlns:converters="clr-namespace:Snoop.Converters"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:snoop="clr-namespace:Snoop"
+      mc:Ignorable="d"
+      x:Name="behaviorView">
+    <Grid Visibility="{Binding HasBehaviors, ElementName=behaviorView, Converter={x:Static converters:BoolToVisibilityConverter.DefaultInstance}}">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="1*"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="2*"/>
+        </Grid.RowDefinitions>
+
+        <ListBox Grid.Row="0" ItemsSource="{Binding Behaviors, ElementName=behaviorView}" SelectedItem="{Binding SelectedBehavior, ElementName=behaviorView}" />
+
+        <GridSplitter Grid.Row="1" Height="4" HorizontalAlignment="Stretch" />
+
+        <snoop:PropertyInspector Grid.Row="2" RootTarget="{Binding Path=SelectedBehavior, ElementName=behaviorView}"/>
+    </Grid>
+
+    <TextBlock Style="{x:Null}"
+               HorizontalAlignment="Center"
+               VerticalAlignment="Center"
+               Text="The element has no behaviors"
+               Visibility="{Binding HasBehaviors, ElementName=behaviorView, Converter={x:Static converters:BoolToVisibilityConverter.DefaultInstance}, ConverterParameter=True}"
+               Opacity="0.6" />
+</Grid>

--- a/Snoop.Core/BehaviorsTab/BehaviorsView.xaml.cs
+++ b/Snoop.Core/BehaviorsTab/BehaviorsView.xaml.cs
@@ -1,0 +1,138 @@
+﻿namespace Snoop.BehaviorsTab
+{
+    using System;
+    using System.Collections;
+    using System.Collections.ObjectModel;
+    using System.Reflection;
+    using System.Windows;
+
+    public partial class BehaviorsView
+    {
+        public BehaviorsView()
+        {
+            this.InitializeComponent();
+
+            this.Behaviors = new ObservableCollection<object>();
+            this.Behaviors.CollectionChanged += (s, e) => this.HasBehaviors = this.Behaviors.Count != 0;
+
+            this.Loaded += this.HandleLoaded;
+            this.Unloaded += this.HandleUnloaded;
+        }
+
+        public static readonly DependencyProperty IsSelectedProperty = DependencyProperty.Register("IsSelected", typeof(bool), typeof(BehaviorsView), new PropertyMetadata(default(bool), OnIsSelectedChanged));
+
+        public bool IsSelected
+        {
+            get { return (bool) this.GetValue(IsSelectedProperty); }
+            set { this.SetValue(IsSelectedProperty, value); }
+        }
+
+        private static void OnIsSelectedChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            var view = (BehaviorsView) d;
+            view.Update();
+        }
+
+        public static readonly DependencyProperty RootTargetProperty = DependencyProperty.Register("RootTarget", typeof(object), typeof(BehaviorsView), new PropertyMetadata(default(object), OnRootTargetChanged));
+
+        public object RootTarget
+        {
+            get { return this.GetValue(RootTargetProperty); }
+            set { this.SetValue(RootTargetProperty, value); }
+        }
+
+        private static void OnRootTargetChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            var view = (BehaviorsView) d;
+            view.Update();
+        }
+
+        private static readonly DependencyProperty BehaviorsProperty = DependencyProperty.Register("Behaviors", typeof(ObservableCollection<object>), typeof(BehaviorsView), new PropertyMetadata(default(ObservableCollection<object>)));
+
+        public ObservableCollection<object> Behaviors
+        {
+            get { return (ObservableCollection<object>) this.GetValue(BehaviorsProperty); }
+            set { this.SetValue(BehaviorsProperty, value); }
+        }
+
+        private static readonly DependencyProperty SelectedBehaviorProperty = DependencyProperty.Register("SelectedBehavior", typeof(object), typeof(BehaviorsView), new PropertyMetadata(default(object)));
+
+        public object SelectedBehavior
+        {
+            get { return this.GetValue(SelectedBehaviorProperty); }
+            set { this.SetValue(SelectedBehaviorProperty, value); }
+        }
+
+        private static readonly DependencyPropertyKey HasBehaviorsPropertyKey = DependencyProperty.RegisterReadOnly("HasBehaviors", typeof(bool), typeof(BehaviorsView), new FrameworkPropertyMetadata(default(bool)));
+        
+        public static readonly DependencyProperty HasBehaviorsProperty = HasBehaviorsPropertyKey.DependencyProperty;
+
+        public bool HasBehaviors
+        {
+            get { return (bool) this.GetValue(HasBehaviorsProperty); }
+            protected set { this.SetValue(HasBehaviorsPropertyKey, value); }
+        }
+
+        private void HandleLoaded(object sender, RoutedEventArgs routedEventArgs)
+        {
+            this.Update();
+        }
+
+        private void HandleUnloaded(object sender, RoutedEventArgs routedEventArgs)
+        {
+            this.Cleanup();
+        }
+
+        private void Cleanup()
+        {
+            this.Behaviors.Clear();
+        }
+
+        private void Update()
+        {
+            // Always cleanup first
+            this.Cleanup();
+
+            if (this.IsSelected)
+            {
+                this.UpdateBehaviorList(this.RootTarget);
+            }
+        }
+
+        private void UpdateBehaviorList(object target)
+        {
+            if (target == null)
+            {
+                return;
+            }
+
+            var depObj = target as DependencyObject;
+            if (depObj != null)
+            {
+                this.AddBehaviorsFromType(depObj, "System.Windows.Interactivity.Interaction, System.Windows.Interactivity");
+                this.AddBehaviorsFromType(depObj, "Microsoft.Xaml.Behaviors.Interaction, Microsoft.Xaml.Behaviors");
+            }
+        }
+
+        private void AddBehaviorsFromType(DependencyObject dependencyObject, string assemblyQualifiedName)
+        {
+            var interactivityType = Type.GetType(assemblyQualifiedName, false);
+
+            if (interactivityType != null)
+            {
+                var getBehaviorsMethod = interactivityType.GetMethod("GetBehaviors", BindingFlags.Static | BindingFlags.Public);
+
+                if (getBehaviorsMethod == null) return;
+
+                var behaviorsToAdd = getBehaviorsMethod.Invoke(null, new object[] { dependencyObject }) as IEnumerable;
+
+                if (behaviorsToAdd == null) return;
+
+                foreach (object behavior in behaviorsToAdd)
+                {
+                    this.Behaviors.Add(behavior);
+                }
+            }
+        }
+    }
+}

--- a/Snoop.Core/SnoopUI.xaml
+++ b/Snoop.Core/SnoopUI.xaml
@@ -17,6 +17,7 @@ All other rights reserved.
 	xmlns:MethodsTabNS="clr-namespace:Snoop.MethodsTab"
     xmlns:DebugListenerNS="clr-namespace:Snoop.DebugListenerTab"
     xmlns:triggersTab="clr-namespace:Snoop.TriggersTab"
+    xmlns:behaviorsTab="clr-namespace:Snoop.BehaviorsTab"
     xmlns:windows="clr-namespace:Snoop.Windows"
     mc:Ignorable="d"
 	Icon="Snoop.ico"
@@ -306,6 +307,24 @@ All other rights reserved.
 		        <triggersTab:TriggersView RootTarget="{Binding CurrentSelection.Target}"
 		                                  IsSelected="{Binding IsSelected, RelativeSource={RelativeSource AncestorType={x:Type TabItem}}}" />
 		    </TabItem>
+			<TabItem Style="{x:Null}">
+				<TabItem.Header>
+					<TextBlock Style="{x:Null}" Text="Behaviors">
+						<TextBlock.ToolTip>
+							<StackPanel MaxWidth="300">
+								<TextBlock Style="{x:Null}" Text="Behaviors View"/>
+								<TextBlock
+									Style="{x:Null}"
+									Text="Lists all behaviors on currently selected object."
+									TextWrapping="Wrap"
+								/>
+							</StackPanel>
+						</TextBlock.ToolTip>
+					</TextBlock>
+				</TabItem.Header>
+				<behaviorsTab:BehaviorsView RootTarget="{Binding CurrentSelection.Target}"
+											IsSelected="{Binding IsSelected, RelativeSource={RelativeSource AncestorType={x:Type TabItem}}}" />
+			</TabItem>
 
 			<TabItem Style="{x:Null}">
 				<TabItem.Header>


### PR DESCRIPTION
Mostly the same as the code in the Triggers tab.

The code dynamically tries to load the types `System.Windows.Interactivity.Interaction` (the old Exrepssion Blend stuff) and `Microsoft.Xaml.Behaviors.Interaction` (the new open sourced stuff).
Then it tries to invoke the `GetBehaviors` static method via reflection.

This should give back the list of behaviors for the current element.