### PR TITLE
Drastically improved performance of AppChooser.Refresh()

### DIFF
--- a/Snoop/AppChooser.xaml.cs
+++ b/Snoop/AppChooser.xaml.cs
@@ -62,13 +62,18 @@ namespace Snoop
                     {
                         Mouse.OverrideCursor = Cursors.Wait;
 
-                        foreach (var windowHandle in NativeMethods.ToplevelWindows)
+                        var processes = Process.GetProcesses().Except(new[] { Process.GetCurrentProcess() });
+
+                        foreach (var process in processes)
                         {
-                            var windowInfo = new WindowInfo(windowHandle);
-                            if (windowInfo.IsValidProcess
-                                && !this.IsAlreadInList(windowInfo.OwningProcessInfo.Process))
+                            var windows = NativeMethods.GetRootWindowsOfProcess(process.Id);
+                            var windowInfoCollection = windows.Select(h => new WindowInfo(h, process));
+                            foreach (var windowInfo in windowInfoCollection)
                             {
-                                this.windowInfos.Add(windowInfo);
+                                if (windowInfo.IsValidProcess && !this.IsAlreadInList(process))
+                                {
+                                    this.windowInfos.Add(windowInfo);
+                                }
                             }
                         }
 

--- a/Snoop/WindowInfo.cs
+++ b/Snoop/WindowInfo.cs
@@ -23,6 +23,12 @@ namespace Snoop
             this.HWnd = hwnd;
         }
 
+        public WindowInfo(IntPtr hwnd, Process owningProcess)
+        : this(hwnd)
+        {
+            this.owningProcessInfo = new ProcessInfo(owningProcess);
+        }
+
         public static void ClearCachedWindowHandleInfo()
         {
             windowHandleToValidityMap.Clear();


### PR DESCRIPTION
Hello pals:

The goal is to eliminate overburning with useless calls of GetProcessById.
So performance benefit is almost 10 times. For my case 4 seconds against 40.

Welcome to discuss)