### PR TITLE
Usability improvements for process dropdown

### DIFF
--- a/Snoop/AppChooser.xaml
+++ b/Snoop/AppChooser.xaml
@@ -21,7 +21,7 @@ All other rights reserved.
 	Title="Snoop"
 	SizeToContent="Width"
 	Height="26"
-    MinHeight="26"
+  MinHeight="26"
 	ResizeMode="NoResize"
 	MouseLeftButtonDown="HandleMouseLeftButtonDown"
 	SnapsToDevicePixels="False"
@@ -32,6 +32,7 @@ All other rights reserved.
 	Foreground="{x:Null}"
 	Style="{DynamicResource windowStyle}"
 	DataContext="{Binding RelativeSource={RelativeSource Self}}"
+  x:Name="Root"
 >
 	<Window.Resources>
 		<!-- mouseOverBackgroundBrush -->
@@ -269,26 +270,53 @@ All other rights reserved.
             </Border>
 
             <TextBlock Grid.Column="1"
-                       Style="{x:Null}"
                        Text="{Binding ProcessId, StringFormat={}[{0}]}"
-                       Margin="0,0,6,0">
+                       Margin="0,0,6,0"
+                       MouseRightButtonUp="HandleDropDownColumn_OnMouseRightButtonUp">
+              <TextBlock.Style>
+                <Style TargetType="{x:Type TextBlock}">
+                  <Style.Triggers>
+                    <DataTrigger Binding="{Binding Path=DataContext.SortColumn, ElementName=Root}" Value="1">
+                      <Setter Property="TextBlock.FontWeight" Value="Bold"/>
+                    </DataTrigger>
+                  </Style.Triggers>
+                </Style>
+              </TextBlock.Style>
               <TextBlock.ToolTip>
                 <Run Text="{Binding ProcessId, Mode=OneWay, StringFormat={}PID: &#x2019;{0}&#x2019;}"/>
               </TextBlock.ToolTip>
             </TextBlock>
 
             <TextBlock Grid.Column="2"
-                       Style="{x:Null}"
                        Text="{Binding ProcessName}"
-                       Margin="0,0,6,0">
+                       Margin="0,0,6,0"
+                       MouseRightButtonUp="HandleDropDownColumn_OnMouseRightButtonUp">
+              <TextBlock.Style>
+                <Style TargetType="{x:Type TextBlock}">
+                  <Style.Triggers>
+                    <DataTrigger Binding="{Binding Path=DataContext.SortColumn, ElementName=Root}" Value="2">
+                      <Setter Property="TextBlock.FontWeight" Value="Bold"/>
+                    </DataTrigger>
+                  </Style.Triggers>
+                </Style>
+              </TextBlock.Style>
               <TextBlock.ToolTip>
                 <Run Text="{Binding Path=ProcessName, Mode=OneWay, StringFormat={}Process name: &#x2019;{0}&#x2019;}"/>
               </TextBlock.ToolTip>
             </TextBlock>
 
             <TextBlock Grid.Column="3"
-                       Style="{x:Null}"
-                       Text="{Binding WindowTitle}">
+                       Text="{Binding WindowTitle}"
+                       MouseRightButtonUp="HandleDropDownColumn_OnMouseRightButtonUp">
+              <TextBlock.Style>
+                <Style TargetType="{x:Type TextBlock}">
+                  <Style.Triggers>
+                    <DataTrigger Binding="{Binding Path=DataContext.SortColumn, ElementName=Root}" Value="3">
+                      <Setter Property="TextBlock.FontWeight" Value="Bold"/>
+                    </DataTrigger>
+                  </Style.Triggers>
+                </Style>
+              </TextBlock.Style>
               <TextBlock.ToolTip>
                 <Run Text="{Binding Path=WindowTitle, Mode=OneWay, StringFormat={}Window title: &#x2019;{0}&#x2019;}"/>
               </TextBlock.ToolTip>

--- a/Snoop/AppChooser.xaml
+++ b/Snoop/AppChooser.xaml
@@ -283,7 +283,11 @@ All other rights reserved.
                 </Style>
               </TextBlock.Style>
               <TextBlock.ToolTip>
-                <Run Text="{Binding ProcessId, Mode=OneWay, StringFormat={}PID: &#x2019;{0}&#x2019;}"/>
+                <TextBlock>
+                  <Run Text="{Binding ProcessId, Mode=OneWay, StringFormat={}PID: &#x2019;{0}&#x2019;}"/>
+                  <LineBreak/>
+                  <Run Text="Right mouse button click to sort"/>
+                </TextBlock>
               </TextBlock.ToolTip>
             </TextBlock>
 
@@ -301,7 +305,11 @@ All other rights reserved.
                 </Style>
               </TextBlock.Style>
               <TextBlock.ToolTip>
-                <Run Text="{Binding Path=ProcessName, Mode=OneWay, StringFormat={}Process name: &#x2019;{0}&#x2019;}"/>
+                <TextBlock>
+                  <Run Text="{Binding Path=ProcessName, Mode=OneWay, StringFormat={}Process name: &#x2019;{0}&#x2019;}"/>
+                  <LineBreak/>
+                  <Run Text="Right mouse button click to sort"/>
+                </TextBlock>
               </TextBlock.ToolTip>
             </TextBlock>
 
@@ -318,7 +326,11 @@ All other rights reserved.
                 </Style>
               </TextBlock.Style>
               <TextBlock.ToolTip>
-                <Run Text="{Binding Path=WindowTitle, Mode=OneWay, StringFormat={}Window title: &#x2019;{0}&#x2019;}"/>
+                <TextBlock>
+                  <Run Text="{Binding Path=WindowTitle, Mode=OneWay, StringFormat={}Window title: &#x2019;{0}&#x2019;}"/>
+                  <LineBreak/>
+                  <Run Text="Right mouse button click to sort"/>
+                </TextBlock>
               </TextBlock.ToolTip>
             </TextBlock>
           </Grid>

--- a/Snoop/AppChooser.xaml
+++ b/Snoop/AppChooser.xaml
@@ -15,6 +15,7 @@ All other rights reserved.
 	xmlns:infrastructure="clr-namespace:Snoop.Infrastructure"
 	xmlns:converters="clr-namespace:Snoop.Converters"
 	xmlns:snoop="urn:snoopwpf"
+	xmlns:componentModel="clr-namespace:System.ComponentModel;assembly=WindowsBase"
 	x:Class="Snoop.AppChooser"
 	Icon="Snoop.ico"
 	Title="Snoop"
@@ -231,7 +232,8 @@ All other rights reserved.
 		</StackPanel>
 
 		<!-- windows combo box -->
-		<ComboBox
+    <ComboBox
+			Grid.IsSharedSizeScope="True"
 			x:Name="windowsComboBox"
 			Grid.Column="1"
 			VerticalAlignment="Center"
@@ -247,29 +249,99 @@ All other rights reserved.
 			FocusVisualStyle="{DynamicResource simpleComboBoxFocusStyle}"
 			DropDownOpened="HandleWindowsComboBox_OnDropDownOpened"
 			ToolTip="This combo box shows the list of applications that can be Snoop(ed).">
-            <ComboBox.ItemTemplate>
-                <DataTemplate DataType="my:WindowInfo">
-                    <Grid Style="{x:Null}">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="Auto" />
-                        </Grid.ColumnDefinitions>
-                        <Border Grid.Column="0"
-                                Style="{x:Null}"
-                                Width="16"
-                                Height="16">
-                            <Image Style="{x:Null}"
-                                   Visibility="{Binding OwningProcessInfo.IsProcessElevated, Converter={x:Static snoop:BoolToVisibilityConverter.DefaultInstance}}"
-                                   Source="{Binding Source={x:Static infrastructure:SystemIcon.Shield}, Converter={x:Static converters:SystemIconToImageSourceConverter.Instance}, ConverterParameter=16}" />
-                        </Border>
+      <ComboBox.Resources>
+        <!-- Drop down list item template -->
+        <DataTemplate x:Key="DropDownItemTemplate" DataType="{x:Type my:WindowInfo}">
+          <Grid Style="{x:Null}">
+            <Grid.ColumnDefinitions>
+              <ColumnDefinition Width="Auto" SharedSizeGroup="Column1"/>
+              <ColumnDefinition Width="Auto" SharedSizeGroup="Column2"/>
+              <ColumnDefinition Width="Auto" SharedSizeGroup="Column3"/>
+              <ColumnDefinition Width="Auto" SharedSizeGroup="Column4"/>
+            </Grid.ColumnDefinitions>
+            <Border Grid.Column="0"
+                    Style="{x:Null}"
+                    Width="16"
+                    Height="16">
+              <Image Style="{x:Null}"
+                     Visibility="{Binding OwningProcessInfo.IsProcessElevated, Converter={x:Static snoop:BoolToVisibilityConverter.DefaultInstance}}"
+                     Source="{Binding Source={x:Static infrastructure:SystemIcon.Shield}, Converter={x:Static converters:SystemIconToImageSourceConverter.Instance}, ConverterParameter=16}" />
+            </Border>
 
-                        <TextBlock Grid.Column="1" 
-                                   Style="{x:Null}"
-                                   Text="{Binding}" />
-                    </Grid>
-                </DataTemplate>
-            </ComboBox.ItemTemplate>
-		</ComboBox>
+            <TextBlock Grid.Column="1"
+                       Style="{x:Null}"
+                       Text="{Binding ProcessId, StringFormat={}[{0}]}"
+                       Margin="0,0,6,0">
+              <TextBlock.ToolTip>
+                <Run Text="{Binding ProcessId, Mode=OneWay, StringFormat={}PID: &#x2019;{0}&#x2019;}"/>
+              </TextBlock.ToolTip>
+            </TextBlock>
+
+            <TextBlock Grid.Column="2"
+                       Style="{x:Null}"
+                       Text="{Binding ProcessName}"
+                       Margin="0,0,6,0">
+              <TextBlock.ToolTip>
+                <Run Text="{Binding Path=ProcessName, Mode=OneWay, StringFormat={}Process name: &#x2019;{0}&#x2019;}"/>
+              </TextBlock.ToolTip>
+            </TextBlock>
+
+            <TextBlock Grid.Column="3"
+                       Style="{x:Null}"
+                       Text="{Binding WindowTitle}">
+              <TextBlock.ToolTip>
+                <Run Text="{Binding Path=WindowTitle, Mode=OneWay, StringFormat={}Window title: &#x2019;{0}&#x2019;}"/>
+              </TextBlock.ToolTip>
+            </TextBlock>
+          </Grid>
+        </DataTemplate>
+        <!-- Selection item template for compact representation -->
+        <DataTemplate x:Key="SelectionItemTemplate" DataType="{x:Type my:WindowInfo}">
+          <Grid>
+            <Grid.ColumnDefinitions>
+              <ColumnDefinition Width="Auto"/>
+              <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+            <Border Grid.Column="0"
+                    Style="{x:Null}"
+                    Width="16"
+                    Height="16">
+              <Image Style="{x:Null}"
+                     Visibility="{Binding OwningProcessInfo.IsProcessElevated, Converter={x:Static snoop:BoolToVisibilityConverter.DefaultInstance}}"
+                     Source="{Binding Source={x:Static infrastructure:SystemIcon.Shield}, Converter={x:Static converters:SystemIconToImageSourceConverter.Instance}, ConverterParameter=16}" />
+            </Border>
+            <TextBlock Grid.Column="1"
+                       Style="{x:Null}">
+              <TextBlock.Text>
+                <MultiBinding StringFormat="{}[{0}] - {1} - {2}">
+                  <MultiBinding.Bindings>
+                    <Binding Path="ProcessId"/>
+                    <Binding Path="ProcessName"/>
+                    <Binding Path="WindowTitle"/>
+                  </MultiBinding.Bindings>
+                </MultiBinding>
+              </TextBlock.Text>
+            </TextBlock>
+          </Grid>
+        </DataTemplate>
+      </ComboBox.Resources>
+      <ComboBox.ItemTemplate>
+        <!-- Due to design limitations we can not just set SelectionBoxItemTemplate and be happy -->
+        <DataTemplate DataType="my:WindowInfo">
+          <ContentPresenter x:Name="Presenter"
+                            Content="{Binding}"
+                            ContentTemplate="{StaticResource DropDownItemTemplate}"/>
+          <DataTemplate.Triggers>
+            <DataTrigger
+                Binding="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=ComboBoxItem, AncestorLevel=1}}"
+                Value="{x:Null}">
+              <Setter TargetName="Presenter" Property="ContentTemplate"
+                      Value="{StaticResource SelectionItemTemplate}" />
+            </DataTrigger>
+          </DataTemplate.Triggers>
+        </DataTemplate>
+      </ComboBox.ItemTemplate>
+    </ComboBox>
 
 		<!-- refresh button -->
 		<Button

--- a/Snoop/AppChooser.xaml
+++ b/Snoop/AppChooser.xaml
@@ -15,8 +15,7 @@ All other rights reserved.
 	xmlns:infrastructure="clr-namespace:Snoop.Infrastructure"
 	xmlns:converters="clr-namespace:Snoop.Converters"
 	xmlns:snoop="urn:snoopwpf"
-	xmlns:componentModel="clr-namespace:System.ComponentModel;assembly=WindowsBase"
-	x:Class="Snoop.AppChooser"
+  x:Class="Snoop.AppChooser"
 	Icon="Snoop.ico"
 	Title="Snoop"
 	SizeToContent="Width"
@@ -266,75 +265,79 @@ All other rights reserved.
                     Height="16">
               <Image Style="{x:Null}"
                      Visibility="{Binding OwningProcessInfo.IsProcessElevated, Converter={x:Static snoop:BoolToVisibilityConverter.DefaultInstance}}"
-                     Source="{Binding Source={x:Static infrastructure:SystemIcon.Shield}, Converter={x:Static converters:SystemIconToImageSourceConverter.Instance}, ConverterParameter=16}" />
+                     Source="{Binding Source={x:Static infrastructure:SystemIcon.Shield},
+                                                       Converter={x:Static converters:SystemIconToImageSourceConverter.Instance},
+                                                       ConverterParameter=16,
+                                                       Mode=OneTime}" />
             </Border>
 
             <TextBlock Grid.Column="1"
-                       Text="{Binding ProcessId, StringFormat={}[{0}]}"
+                       Text="{Binding ProcessId, StringFormat={}[{0}], Mode=OneTime}"
                        Margin="0,0,6,0"
                        MouseRightButtonUp="HandleDropDownColumn_OnMouseRightButtonUp">
               <TextBlock.Style>
                 <Style TargetType="{x:Type TextBlock}">
                   <Style.Triggers>
-                    <DataTrigger Binding="{Binding Path=DataContext.SortColumn, ElementName=Root}" Value="1">
+                    <DataTrigger Binding="{Binding Path=SortColumn, ElementName=Root}" Value="1">
                       <Setter Property="TextBlock.FontWeight" Value="Bold"/>
                     </DataTrigger>
                   </Style.Triggers>
                 </Style>
               </TextBlock.Style>
               <TextBlock.ToolTip>
-                <TextBlock>
-                  <Run Text="{Binding ProcessId, Mode=OneWay, StringFormat={}PID: &#x2019;{0}&#x2019;}"/>
-                  <LineBreak/>
-                  <Run Text="Right mouse button click to sort"/>
+                <TextBlock Style="{x:Null}">
+                  <Run Text="{Binding ProcessId, Mode=OneTime, StringFormat={}PID: &#x2019;{0}&#x2019;}" Style="{x:Null}"/>
+                  <LineBreak Style="{x:Null}"/>
+                  <Run Text="Right mouse button click to sort" Style="{x:Null}"/>
                 </TextBlock>
               </TextBlock.ToolTip>
             </TextBlock>
 
             <TextBlock Grid.Column="2"
-                       Text="{Binding ProcessName}"
+                       Text="{Binding ProcessName, Mode=OneTime}"
                        Margin="0,0,6,0"
                        MouseRightButtonUp="HandleDropDownColumn_OnMouseRightButtonUp">
               <TextBlock.Style>
                 <Style TargetType="{x:Type TextBlock}">
                   <Style.Triggers>
-                    <DataTrigger Binding="{Binding Path=DataContext.SortColumn, ElementName=Root}" Value="2">
+                    <DataTrigger Binding="{Binding Path=SortColumn, ElementName=Root, Mode=OneWay}" Value="2">
                       <Setter Property="TextBlock.FontWeight" Value="Bold"/>
                     </DataTrigger>
                   </Style.Triggers>
                 </Style>
               </TextBlock.Style>
               <TextBlock.ToolTip>
-                <TextBlock>
-                  <Run Text="{Binding Path=ProcessName, Mode=OneWay, StringFormat={}Process name: &#x2019;{0}&#x2019;}"/>
-                  <LineBreak/>
-                  <Run Text="Right mouse button click to sort"/>
+                <TextBlock Style="{x:Null}">
+                  <Run Text="{Binding Path=ProcessName, Mode=OneTime, StringFormat={}Process name: &#x2019;{0}&#x2019;}" Style="{x:Null}"/>
+                  <LineBreak Style="{x:Null}"/>
+                  <Run Text="Right mouse button click to sort" Style="{x:Null}"/>
                 </TextBlock>
               </TextBlock.ToolTip>
             </TextBlock>
 
             <TextBlock Grid.Column="3"
-                       Text="{Binding WindowTitle}"
+                       Text="{Binding WindowTitle, Mode=OneTime}"
                        MouseRightButtonUp="HandleDropDownColumn_OnMouseRightButtonUp">
               <TextBlock.Style>
                 <Style TargetType="{x:Type TextBlock}">
                   <Style.Triggers>
-                    <DataTrigger Binding="{Binding Path=DataContext.SortColumn, ElementName=Root}" Value="3">
+                    <DataTrigger Binding="{Binding Path=SortColumn, ElementName=Root}" Value="3">
                       <Setter Property="TextBlock.FontWeight" Value="Bold"/>
                     </DataTrigger>
                   </Style.Triggers>
                 </Style>
               </TextBlock.Style>
               <TextBlock.ToolTip>
-                <TextBlock>
-                  <Run Text="{Binding Path=WindowTitle, Mode=OneWay, StringFormat={}Window title: &#x2019;{0}&#x2019;}"/>
-                  <LineBreak/>
-                  <Run Text="Right mouse button click to sort"/>
+                <TextBlock Style="{x:Null}">
+                  <Run Text="{Binding Path=WindowTitle, Mode=OneTime, StringFormat={}Window title: &#x2019;{0}&#x2019;}" Style="{x:Null}"/>
+                  <LineBreak Style="{x:Null}"/>
+                  <Run Text="Right mouse button click to sort" Style="{x:Null}"/>
                 </TextBlock>
               </TextBlock.ToolTip>
             </TextBlock>
           </Grid>
         </DataTemplate>
+
         <!-- Selection item template for compact representation -->
         <DataTemplate x:Key="SelectionItemTemplate" DataType="{x:Type my:WindowInfo}">
           <Grid>
@@ -370,7 +373,8 @@ All other rights reserved.
         <DataTemplate DataType="my:WindowInfo">
           <ContentPresenter x:Name="Presenter"
                             Content="{Binding}"
-                            ContentTemplate="{StaticResource DropDownItemTemplate}"/>
+                            ContentTemplate="{StaticResource DropDownItemTemplate}"
+                            Style="{x:Null}"/>
           <DataTemplate.Triggers>
             <DataTrigger
                 Binding="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=ComboBoxItem, AncestorLevel=1}}"

--- a/Snoop/AppChooser.xaml.cs
+++ b/Snoop/AppChooser.xaml.cs
@@ -37,6 +37,7 @@ namespace Snoop
         public AppChooser()
         {
             this.WindowInfos = CollectionViewSource.GetDefaultView(this.windowInfos);
+            this.WindowInfos?.SortDescriptions.Add(new SortDescription(nameof(WindowInfo.ProcessId), ListSortDirection.Ascending));
 
             this.InitializeComponent();
 

--- a/Snoop/WindowInfo.cs
+++ b/Snoop/WindowInfo.cs
@@ -124,29 +124,7 @@ namespace Snoop
 
         public IntPtr HWnd { get; }
 
-        public string Description
-        {
-            get
-            {
-                var processInfo = this.OwningProcessInfo;
-                var windowTitle = NativeMethods.GetText(this.HWnd);
-
-                if (string.IsNullOrEmpty(windowTitle))
-                {
-                    try
-                    {
-                        windowTitle = processInfo.Process.MainWindowTitle;
-                    }
-                    catch (InvalidOperationException)
-                    {
-                        // The process closed while we were trying to evaluate it
-                        return string.Empty;
-                    }
-                }
-
-                return $"{windowTitle} - {processInfo.Process.ProcessName} [{processInfo.Process.Id}]";
-            }
-        }
+        public string Description => $"{this.WindowTitle} - {this.OwningProcessInfo?.Process?.ProcessName ?? string.Empty} [{this.OwningProcessInfo?.Process?.Id}]";
 
         #region UI Binding sources
 

--- a/Snoop/WindowInfo.cs
+++ b/Snoop/WindowInfo.cs
@@ -148,6 +148,38 @@ namespace Snoop
             }
         }
 
+        #region UI Binding sources
+
+        public string WindowTitle
+        {
+            get
+            {
+                var processInfo = this.OwningProcessInfo;
+                var windowTitle = NativeMethods.GetText(this.HWnd);
+
+                if (string.IsNullOrEmpty(windowTitle))
+                {
+                    try
+                    {
+                        windowTitle = processInfo.Process.MainWindowTitle;
+                    }
+                    catch (InvalidOperationException)
+                    {
+                        // The process closed while we were trying to evaluate it
+                        return string.Empty;
+                    }
+                }
+
+                return windowTitle;
+            }
+        }
+
+        public string ProcessName => this.OwningProcessInfo?.Process?.ProcessName;
+
+        public int ProcessId => this.OwningProcessInfo?.Process?.Id ?? -1;
+
+        #endregion
+
         public string ClassName => NativeMethods.GetClassName(this.HWnd);
 
         public string TraceInfo => $"{this.Description} [{this.HWnd.ToInt64():X8}] {this.ClassName}";


### PR DESCRIPTION
Implemented some tiny useful stuff for process selector drop down list:
1. A table-like view to ease information acceptance for human eye
2. Sorting of drop down by process id, process name and window title by right mouse button click. Table is sorted by PID by-default.
3. Tooltips for each column with hint about sorting feature.
4. Current sorting column is marked with bold.

How it was to be:
![image](https://user-images.githubusercontent.com/13204542/74598730-c68a9780-5087-11ea-8a18-bd648a1d4818.png)

And how it looks now:
![image](https://user-images.githubusercontent.com/13204542/74598736-d30ef000-5087-11ea-8360-ce995b115e76.png)


