### PR TITLE
Making retrieval of binding errors lazy

### DIFF
--- a/Snoop.Core/Controls/PropertyGrid2.xaml
+++ b/Snoop.Core/Controls/PropertyGrid2.xaml
@@ -8,7 +8,7 @@ All other rights reserved.
 	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 	x:Class="Snoop.Controls.PropertyGrid2"
-	xmlns:snoop="clr-namespace:Snoop"
+	xmlns:snoop="urn:snoopwpf"
 	xmlns:controls="clr-namespace:Snoop.Controls"
 	x:Name="PropertyGrid"
 	MinHeight="0"
@@ -222,11 +222,23 @@ All other rights reserved.
 					</GridViewColumn.Header>
 					<GridViewColumn.CellTemplate>
 						<DataTemplate DataType="snoop:PropertyInformation">
-							<TextBlock Style="{x:Null}" Text="{Binding BindingError}" Height="15">
-								<TextBlock.ToolTip>
-									<TextBlock Style="{x:Null}" Text="{Binding BindingError}"/>
-								</TextBlock.ToolTip>
-							</TextBlock>
+							<StackPanel Orientation="Horizontal" Visibility="{Binding IsInvalidBinding, Converter={x:Static snoop:BoolToVisibilityConverter.DefaultInstance}}">
+                                <Button Style="{x:Null}" Content="Get error message" 
+                                        Command="{x:Static controls:PropertyInspector.UpdateBindingErrorCommand}" CommandParameter="{Binding}">
+									<Button.Visibility>
+										<MultiBinding Converter="{x:Static snoop:BoolToVisibilityConverter.DefaultInstance}">
+											<Binding Path="BindingError" Converter="{x:Static snoop:IsNullOrEmptyStringConverter.DefaultInstance}" />
+                                        </MultiBinding>
+                                    </Button.Visibility>
+                                </Button>
+                                <TextBox Style="{x:Null}" Text="{Binding BindingError, Mode=OneWay}" Height="15"
+                                         IsReadOnly="True"
+                                         IsReadOnlyCaretVisible="True">
+								    <TextBox.ToolTip>
+									    <TextBlock Style="{x:Null}" Text="{Binding BindingError}"/>
+								    </TextBox.ToolTip>
+							    </TextBox>
+                            </StackPanel>
 						</DataTemplate>
 					</GridViewColumn.CellTemplate>
 				</GridViewColumn>

--- a/Snoop.Core/Controls/PropertyInspector.xaml.cs
+++ b/Snoop.Core/Controls/PropertyInspector.xaml.cs
@@ -32,6 +32,8 @@ namespace Snoop.Controls
 
         public static readonly RoutedCommand NavigateToAssemblyInExplorerCommand = new RoutedCommand(nameof(NavigateToAssemblyInExplorerCommand), typeof(PropertyInspector));
 
+        public static readonly RoutedCommand UpdateBindingErrorCommand = new RoutedCommand(nameof(UpdateBindingErrorCommand), typeof(PropertyInspector));
+
         private object target;
 
         public PropertyInspector()
@@ -50,7 +52,8 @@ namespace Snoop.Controls
             this.CommandBindings.Add(new CommandBinding(CopyXamlCommand, this.HandleCopyXaml, this.CanCopyXaml));
 
             this.CommandBindings.Add(new CommandBinding(NavigateToAssemblyInExplorerCommand, this.HandleNavigateToAssemblyInExplorer, this.CanNavigateToAssemblyInExplorer));
-
+            this.CommandBindings.Add(new CommandBinding(UpdateBindingErrorCommand, this.HandleUpdateBindingError, this.CanUpdateBindingError));
+            
             // watch for mouse "back" button
             this.MouseDown += this.MouseDownHandler;
             this.KeyDown += this.PropertyInspector_KeyDown;
@@ -431,12 +434,30 @@ namespace Snoop.Controls
             }
             catch
             {
+                // ignored
             }
         }
 
         private void CanNavigateToAssemblyInExplorer(object sender, CanExecuteRoutedEventArgs e)
         {
             e.CanExecute = e.Parameter is Type;
+        }
+
+        private void CanUpdateBindingError(object sender, CanExecuteRoutedEventArgs e)
+        {
+            if (e.Parameter is PropertyInformation propertyInformation)
+            {
+                e.CanExecute = propertyInformation.IsInvalidBinding
+                               && string.IsNullOrEmpty(propertyInformation.BindingError);
+            }
+        }
+
+        private void HandleUpdateBindingError(object sender, ExecutedRoutedEventArgs e)
+        {
+            if (e.Parameter is PropertyInformation propertyInformation)
+            {
+                propertyInformation.UpdateBindingError();
+            }
         }
 
         public PropertyFilter PropertyFilter

--- a/Snoop.Core/Converters/BoolToVisibilityConverter.cs
+++ b/Snoop.Core/Converters/BoolToVisibilityConverter.cs
@@ -1,10 +1,12 @@
 ﻿namespace Snoop.Converters
 {
     using System;
+    using System.Globalization;
+    using System.Linq;
     using System.Windows;
     using System.Windows.Data;
 
-    public class BoolToVisibilityConverter : IValueConverter
+    public class BoolToVisibilityConverter : IValueConverter, IMultiValueConverter
     {
         public static readonly BoolToVisibilityConverter DefaultInstance = new BoolToVisibilityConverter();
 
@@ -14,14 +16,14 @@
         {
             var invert = false;
 
-            if (parameter is string)
+            if (parameter is string stringParameter)
             {
-                bool.TryParse((string)parameter, out invert);
+                bool.TryParse(stringParameter, out invert);
             }
 
-            if (value is bool)
+            if (value is bool boolValue)
             {
-                return (bool)value ^ invert ? Visibility.Visible : Visibility.Collapsed;
+                return boolValue ^ invert ? Visibility.Visible : Visibility.Collapsed;
             }
 
             return value;
@@ -30,6 +32,29 @@
         public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
             return Binding.DoNothing;
+        }
+
+        #endregion
+
+        #region IValueConverter Members
+
+        public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+        {
+            var invert = false;
+
+            if (parameter is string stringParameter)
+            {
+                bool.TryParse(stringParameter, out invert);
+            }
+
+            var boolValues = values.OfType<bool>();
+
+            return boolValues.All(x => x) ^ invert ? Visibility.Visible : Visibility.Collapsed;
+        }
+
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
         }
 
         #endregion

--- a/Snoop.Core/Converters/IsNullOrEmptyStringConverter.cs
+++ b/Snoop.Core/Converters/IsNullOrEmptyStringConverter.cs
@@ -1,0 +1,26 @@
+﻿namespace Snoop.Converters
+{
+    using System;
+    using System.Globalization;
+    using System.Windows.Data;
+
+    public class IsNullOrEmptyStringConverter : IValueConverter
+    {
+        public static readonly IsNullOrEmptyStringConverter DefaultInstance = new IsNullOrEmptyStringConverter();
+
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is string stringValue)
+            {
+                return string.IsNullOrEmpty(stringValue);
+            }
+
+            return value is null;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return Binding.DoNothing;
+        }
+    }
+}


### PR DESCRIPTION
We have to retrieve binding errors lazy as we otherwise modify a binding before giving anyone a chance to realize that it's broken.
The previous implementation could case binding errors to be hidden because retrieving the error requires to re-set the binding which might fix some binding errors just because of that.