### PR TITLE
Update continuous.yml

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -25,12 +25,12 @@ jobs:
         run: ./dotnet-install.ps1 -Version 6.0.400 -InstallDir "C:\Program Files\dotnet"
       - name: Run './build.cmd CI'
         run: ./build.cmd CI
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: test-results
           path: output/test-results
         if: ${{ always() }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: artifacts
           path: artifacts


### PR DESCRIPTION
upgrade actions/upload-artifact version to v3 to avoid node.js warning in github action.