### PR TITLE
Improve the dark theme.

### DIFF
--- a/Snoop.Core/ThemeManager.cs
+++ b/Snoop.Core/ThemeManager.cs
@@ -139,10 +139,10 @@ public class ThemeManager
     private static Color Invert(Color original)
     {
         var invertedColor = default(Color);
-        invertedColor.ScR = 1.0F - original.ScR;
-        invertedColor.ScG = 1.0F - original.ScG;
-        invertedColor.ScB = 1.0F - original.ScB;
-        invertedColor.ScA = original.ScA;
+        invertedColor.R = (byte)(255 - original.R);
+        invertedColor.G = (byte)(255 - original.G);
+        invertedColor.B = (byte)(255 - original.B);
+        invertedColor.A = original.A;
         return invertedColor;
     }
 }


### PR DESCRIPTION
Previously, there were issues with the contrast levels in the dark theme. Here's an example using the alternate row background color "Snoop.Brushes.ItemsControl.AlternationBackground". Contrast values come from the tool https://webaim.org/resources/contrastchecker/

Light theme:
Background: FFFFFF
Alternate: EAEAEA
Contrast: 1.2

Dark theme:
Background: 000000
Alternate: 757575
Contrast 4.55

Dark theme (with this change)
Background: 000000
Foreground: 151515
Contrast: 1.14

Without this change, the contrast between the background colors of two adjacent rows is 4.55, which is very distracting. That's the kind of contrast you would want between foreground and background, not between two adjacent parts of the background. With the change, the contrast is 1.14, which is very close to the contrast in the light theme of 1.2.

Light Theme
<img width="1073" alt="light1" src="https://user-images.githubusercontent.com/53135437/211870833-8b58131d-e604-4a51-bb93-48b4a2256775.png">

Dark Theme (old)
<img width="1073" alt="image" src="https://user-images.githubusercontent.com/53135437/211871138-58817bff-a618-49fa-8400-3ba4cb690d06.png">

Dark Theme (new)
<img width="1073" alt="image" src="https://user-images.githubusercontent.com/53135437/211871162-39320971-17b8-4309-ad45-4a7f79a46c40.png">
