### PR TITLE
Add .NET Framework reference assemblies NuGet

### DIFF
--- a/Directory.build.targets
+++ b/Directory.build.targets
@@ -1,7 +1,7 @@
 ﻿<Project>
   <!-- Build references -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net452" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" IncludeAssets="build; native" />
   </ItemGroup>
 

--- a/Directory.build.targets
+++ b/Directory.build.targets
@@ -1,6 +1,7 @@
 ﻿<Project>
   <!-- Build references -->
   <ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" IncludeAssets="build; native" />
   </ItemGroup>
 

--- a/Directory.packages.props
+++ b/Directory.packages.props
@@ -19,7 +19,7 @@
     </ItemGroup>
 
     <ItemGroup Label="Build">
-        <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
+        <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies.net452" Version="1.0.3" />
         <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
 
         <PackageVersion Include="JetBrains.Annotations" Version="2022.3.1" />

--- a/Directory.packages.props
+++ b/Directory.packages.props
@@ -19,6 +19,7 @@
     </ItemGroup>
 
     <ItemGroup Label="Build">
+        <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
         <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
 
         <PackageVersion Include="JetBrains.Annotations" Version="2022.3.1" />

--- a/Snoop.InjectorLauncher/Snoop.InjectorLauncher.csproj
+++ b/Snoop.InjectorLauncher/Snoop.InjectorLauncher.csproj
@@ -41,11 +41,21 @@
   </ItemGroup>
    
   <Target Name="CompileOtherArches" AfterTargets="Build" Condition="'$(RootBuild)' == 'True'">
+    <!--
+    Need to force re-evaluate after Restore, such that obj\x64\Snoop.InjectorLauncher.csproj.nuget.g.targets gets imported after it's created by Restore.
+    If we reuse the previous evaluation used by Restore, it won't be imported there as it didn't exist yet.
+    Setting a dummy property forces a new evaluation as it can't reuse the previous eval with a different set of properties.
+    -->
     <Message Text="Building injector launcher for x64..." Importance="High" />
-    <MSBuild Projects="$(MSBuildProjectFile)" Targets="Restore;Build" Properties="RootBuild=False;Configuration=$(Configuration);PlatformTarget=x64" RunEachTargetSeparately="false" />
+    <MSBuild Projects="$(MSBuildProjectFile)" Targets="Restore" Properties="RootBuild=False;Configuration=$(Configuration);PlatformTarget=x64" />
+    <MSBuild Projects="$(MSBuildProjectFile)" Targets="Build" Properties="RootBuild=False;Configuration=$(Configuration);PlatformTarget=x64;DummyPropertyToForceReevaluateAfterRestore=true" />
+
     <Message Text="Building injector launcher for ARM..." Importance="High" />
-    <MSBuild Projects="$(MSBuildProjectFile)" Targets="Restore;Build" Properties="RootBuild=False;Configuration=$(Configuration);PlatformTarget=ARM;TargetFramework=net5.0-windows" RunEachTargetSeparately="false" />
+    <MSBuild Projects="$(MSBuildProjectFile)" Targets="Restore" Properties="RootBuild=False;Configuration=$(Configuration);PlatformTarget=ARM;TargetFramework=net5.0-windows" />
+    <MSBuild Projects="$(MSBuildProjectFile)" Targets="Build" Properties="RootBuild=False;Configuration=$(Configuration);PlatformTarget=ARM;TargetFramework=net5.0-windows;DummyPropertyToForceReevaluateAfterRestore=true" />
+
     <Message Text="Building injector launcher for ARM64..." Importance="High" />
-    <MSBuild Projects="$(MSBuildProjectFile)" Targets="Restore;Build" Properties="RootBuild=False;Configuration=$(Configuration);PlatformTarget=ARM64;TargetFramework=net5.0-windows" RunEachTargetSeparately="false" />
+    <MSBuild Projects="$(MSBuildProjectFile)" Targets="Restore" Properties="RootBuild=False;Configuration=$(Configuration);PlatformTarget=ARM64;TargetFramework=net5.0-windows" />
+    <MSBuild Projects="$(MSBuildProjectFile)" Targets="Build" Properties="RootBuild=False;Configuration=$(Configuration);PlatformTarget=ARM64;TargetFramework=net5.0-windows;DummyPropertyToForceReevaluateAfterRestore=true" />
   </Target>
 </Project>


### PR DESCRIPTION
Without this, if the ref assemblies are not installed, you get a build failure:

MSB3644: The reference assemblies for .NETFramework,Version=v4.5.2 were not found.

With this, the repo will be buildable even if they are not installed.