### PR TITLE
Filter depth based on remaining stack size

### DIFF
--- a/Snoop.Core/Infrastructure/NativeMethods.cs
+++ b/Snoop.Core/Infrastructure/NativeMethods.cs
@@ -507,6 +507,9 @@ public static class NativeMethods
     [DllImport("kernel32.dll", SetLastError = true)]
     public static extern bool CloseHandle(IntPtr hHandle);
 
+    [DllImport("kernel32.dll")]
+    public static extern void GetCurrentThreadStackLimits(out IntPtr lowLimit, out IntPtr highLimit);
+
     [DllImport("user32.dll")]
     public static extern IntPtr LoadImage(IntPtr hinst, string lpszName, uint uType, int cxDesired, int cyDesired, uint fuLoad);
 

--- a/Snoop.Core/Snoop.Core.csproj
+++ b/Snoop.Core/Snoop.Core.csproj
@@ -6,6 +6,7 @@
 
     <UseWpf>true</UseWpf>
     <UseWindowsForms>true</UseWindowsForms>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes #417.

This is how it could look like. Seems to be working for me, not sure if you have any systematic testing for this.

I *think* we might not need the `CollapseIfNeeded` anymore but you have more experience in triggering it.