### PR TITLE
Don't build GenericInjector for ARM if ARM MSVC tools not installed

### DIFF
--- a/Snoop.GenericInjector/Snoop.GenericInjector.vcxproj
+++ b/Snoop.GenericInjector/Snoop.GenericInjector.vcxproj
@@ -151,8 +151,8 @@
   </ItemGroup>
   <Import Condition="Exists('$(VCTargetsPath)\Microsoft.Cpp.targets')" Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Target Name="AfterBuild" Condition="'$(RootBuild)' == 'True'">
-    <MSBuild Projects="$(MSBuildProjectFile)" Properties="RootBuild=False;Configuration=$(Configuration);Platform=x64;PlatFormTarget=x64" RunEachTargetSeparately="true" />
-    <MSBuild Projects="$(MSBuildProjectFile)" Properties="RootBuild=False;Configuration=$(Configuration);Platform=ARM;PlatFormTarget=ARM" RunEachTargetSeparately="true" />
-    <MSBuild Projects="$(MSBuildProjectFile)" Properties="RootBuild=False;Configuration=$(Configuration);Platform=ARM64;PlatFormTarget=ARM64" RunEachTargetSeparately="true" />
+    <MSBuild Projects="$(MSBuildProjectFile)" Properties="RootBuild=False;Configuration=$(Configuration);Platform=x64;PlatFormTarget=x64" />
+    <MSBuild Projects="$(MSBuildProjectFile)" Properties="RootBuild=False;Configuration=$(Configuration);Platform=ARM;PlatFormTarget=ARM" Condition="Exists('$(VC_ExecutablePath_x86_ARM)')" />
+    <MSBuild Projects="$(MSBuildProjectFile)" Properties="RootBuild=False;Configuration=$(Configuration);Platform=ARM64;PlatFormTarget=ARM64" Condition="Exists('$(VC_ExecutablePath_x86_ARM64)')" />
   </Target>
 </Project>


### PR DESCRIPTION
This avoids failing the build if `C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.36.32532\bin\Hostx86\arm` is not found.