### PR TITLE
Feature/start minimized

### DIFF
--- a/Snoop.Core/Data/TransientSettingsData.cs
+++ b/Snoop.Core/Data/TransientSettingsData.cs
@@ -40,6 +40,8 @@ public sealed class TransientSettingsData
 
     public bool EnableDiagnostics { get; set; }
 
+    public bool StartMinimized { get; set; }
+
     public string? SnoopInstallPath { get; set; } = Environment.GetEnvironmentVariable(SettingsHelper.SNOOP_INSTALL_PATH_ENV_VAR);
 
     public string WriteToFile()

--- a/Snoop/AppChooser.xaml.cs
+++ b/Snoop/AppChooser.xaml.cs
@@ -55,6 +55,11 @@ public partial class AppChooser
         this.CommandBindings.Add(new CommandBinding(SettingsCommand, this.HandleSettingsCommand));
         this.CommandBindings.Add(new CommandBinding(MinimizeCommand, this.HandleMinimizeCommand));
         this.CommandBindings.Add(new CommandBinding(ApplicationCommands.Close, this.HandleCloseCommand));
+
+        if (Settings.Default.StartMinimized)
+        {
+            this.WindowState = WindowState.Minimized;
+        }
     }
 
     public ICollectionView WindowInfos { get; }

--- a/Snoop/Settings.cs
+++ b/Snoop/Settings.cs
@@ -1,7 +1,6 @@
 ﻿namespace Snoop;
 
 using System;
-using System.Configuration;
 using System.Windows.Input;
 using System.Xml.Serialization;
 using Snoop.Core;

--- a/Snoop/Settings.cs
+++ b/Snoop/Settings.cs
@@ -1,6 +1,7 @@
 ﻿namespace Snoop;
 
 using System;
+using System.Configuration;
 using System.Windows.Input;
 using System.Xml.Serialization;
 using Snoop.Core;
@@ -12,6 +13,7 @@ public sealed class Settings : SettingsBase<Settings>
 {
     private static readonly XmlSerializer serializer = new(typeof(Settings));
 
+    private bool startMinimized;
     private bool enableDiagnostics = true;
     private KeyGestureEx? globalHotKey = new(Key.F12, ModifierKeys.Control | ModifierKeys.Windows | ModifierKeys.Alt);
     private string? ilSpyPath = "%path%";
@@ -137,6 +139,21 @@ public sealed class Settings : SettingsBase<Settings>
         }
     }
 
+    public bool StartMinimized
+    {
+        get => this.startMinimized;
+        set
+        {
+            if (value == this.startMinimized)
+            {
+                return;
+            }
+
+            this.startMinimized = value;
+            this.OnPropertyChanged();
+        }
+    }
+
     protected override void UpdateWith(Settings settings)
     {
         this.SetOwnerWindow = settings.SetOwnerWindow;
@@ -150,5 +167,7 @@ public sealed class Settings : SettingsBase<Settings>
         this.GlobalHotKey = settings.GlobalHotKey;
 
         this.ILSpyPath = settings.ILSpyPath;
+
+        this.StartMinimized = settings.StartMinimized;
     }
 }

--- a/Snoop/Views/SettingsView.xaml.cs
+++ b/Snoop/Views/SettingsView.xaml.cs
@@ -18,6 +18,7 @@ public partial class SettingsView
         nameof(Settings.Default.EnableDiagnostics),
         nameof(Settings.Default.GlobalHotKey),
         nameof(Settings.Default.ILSpyPath),
+        nameof(Settings.Default.StartMinimized),
     };
 
     public static readonly DependencyProperty PropertiesProperty = DependencyProperty.Register(nameof(Properties), typeof(ObservableCollection<PropertyInformation>), typeof(SettingsView), new PropertyMetadata(default(ObservableCollection<PropertyInformation>)));

--- a/Snoop/app.config
+++ b/Snoop/app.config
@@ -28,6 +28,9 @@
             <setting name="EnableDiagnostics" serializeAs="String">
                 <value>True</value>
             </setting>
+            <setting name="StartMinimized" serializeAs="String">
+                <value>True</value>
+            </setting>
         </Snoop.Properties.Settings>
     </userSettings>
     <startup>


### PR DESCRIPTION
In my day-to-day, I almost always have Snoop running as it is at this point almost instrumental to my workflow. I am also an avid hotkey/macro/shortcut user.

Very rarely do I actually use the Drag and Drop Crosshair feature to select which window I want to inspect, and instead I use the GlobalHotKey. Thus, when I open Snoop in my workflow, it would be a very minor improvement if it would start minimized.

This PR adds the `StartMinimized` setting to `Settings` and `app.config`, with a very simple check in `AppChooser.xaml.cs` to set the `WindowState` to `Minimized` if true.

Please let me know if I need to make any changes, don't want this feature, etc.