### PR TITLE
FilterString to look into Value Type when value is a complex object

### DIFF
--- a/Snoop.Core/Infrastructure/PropertyFilter.cs
+++ b/Snoop.Core/Infrastructure/PropertyFilter.cs
@@ -126,6 +126,11 @@ public class PropertyFilter
                 return true;
             }
 
+            if (property.Value?.GetType().Name is { } valueTypeName && this.filterRegex.IsMatch(valueTypeName))
+            {
+                return true;
+            }
+
             return false;
         }
 
@@ -139,6 +144,11 @@ public class PropertyFilter
 
             if (property.Property is not null
                 && property.Property.PropertyType.Name.ContainsIgnoreCase(this.FilterString))
+            {
+                return true;
+            }
+
+            if (property.Value?.GetType().Name is { } valueTypeName && valueTypeName.ContainsIgnoreCase(valueTypeName))
             {
                 return true;
             }


### PR DESCRIPTION
Hi there,

PR for a really simple feature that would have been helping me multiple times.

Current filter does not search into Value column when value is a complex type (example a ViewModel)
This feature would be really useful for control frameworks like DX using complex templating.

Before change:
![SnoopBefore2](https://github.com/snoopwpf/snoopwpf/assets/6773424/a9745f18-67ef-41ac-abf7-ae4a431b2495)


After change:
![SnoopAfter2](https://github.com/snoopwpf/snoopwpf/assets/6773424/bffa5a9b-8a19-4fc2-a0be-ded9f03842d7)
