### PR TITLE
Update dead links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,9 +125,9 @@ Unfortunately there isn't any exhaustive documentation on how to use Snoop and t
 
 Here are the links to the current Snoop Tips & Tricks:
 
-- http://www.cplotts.com/2011/02/10/snoop-tips-tricks-1-ctrl-shift-mouse-over
-- http://www.cplotts.com/2011/02/14/snoop-tips-tricks-2-snooping-transient-visuals
-- http://www.cplotts.com/2012/05/31/snoop-tips-tricks-3-the-crosshairs
+- https://www.youtube.com/watch?v=n8EdRR0Tc1k
+- https://www.youtube.com/watch?v=98UEVCQHmVA
+- https://www.youtube.com/watch?v=frXAgGzZnrU
 
 ## Why can't I snoop my application?
 
@@ -157,7 +157,7 @@ Requirements:
 Over time contributions have been added by several people, most notably:
 
 - [Bastian Schmidt](https://github.com/batzen), [batzen.dev](https://batzen.dev) (current maintainer)
-- [Cory Plotts](https://github.com/cplotts), [cplotts.com](https://cplotts.com)
+- [Cory Plotts](https://github.com/cplotts)
 - [Dan Hanan](http://blogs.interknowlogy.com/author/danhanan/)
 - [Andrei Kashcha](http://blog.yasiv.com/)
 - [Maciek Rakowski](https://github.com/MaciekRakowski)


### PR DESCRIPTION
The website cplotts.com seems to no longer be associated with former maintainer Cory Plotts.

This PR removes the direct link to the website and replaces the Tips and Tricks articles with links to the YouTube videos that were embedded in said articles. If you'd prefer some labels (e.g. [Tips & Tricks #1 - Ctrl+Shift mouse over](https://www.youtube.com/watch?v=n8EdRR0Tc1k)), I'd be happy to edit the PR.

There are archive.org snapshots of the articles that could be used instead, however there is little content other than the video.

https://web.archive.org/web/20230608043116/http://www.cplotts.com/2011/02/10/snoop-tips-tricks-1-ctrl-shift-mouse-over
https://web.archive.org/web/20230325211330/http://www.cplotts.com/2011/02/14/snoop-tips-tricks-2-snooping-transient-visuals
https://web.archive.org/web/20230608052134/http://www.cplotts.com/2012/05/31/snoop-tips-tricks-3-the-crosshairs