### PR TITLE
Fix brush binding errors

### DIFF
--- a/Snoop.Core/Controls/ValueEditors/EditorTemplates.xaml
+++ b/Snoop.Core/Controls/ValueEditors/EditorTemplates.xaml
@@ -277,12 +277,9 @@
                     <Rectangle Grid.Column="0"
                                Fill="{StaticResource CheckerboardBrush}" />
                     <Rectangle Grid.Column="0"
+                               Fill="{Binding Value, Converter={x:Static converters:ColorToSolidColorBrushConverter.DefaultInstance}}"
                                Stroke="{TemplateBinding TextElement.Foreground}"
-                               StrokeThickness="1">
-                        <Rectangle.Fill>
-                            <SolidColorBrush Color="{Binding Value}" />
-                        </Rectangle.Fill>
-                    </Rectangle>
+                               StrokeThickness="1" />
                     <TextBlock Grid.Column="1"
                                Margin="5 0 0 0"
                                Text="{Binding DescriptiveValue}"
@@ -302,12 +299,9 @@
                     <Rectangle Grid.Column="0"
                                Fill="{StaticResource CheckerboardBrush}" />
                     <Rectangle Grid.Column="0"
+                               Fill="{Binding Value, Converter={x:Static converters:ColorToSolidColorBrushConverter.DefaultInstance}}"
                                Stroke="{TemplateBinding TextElement.Foreground}"
-                               StrokeThickness="1">
-                        <Rectangle.Fill>
-                            <SolidColorBrush Color="{Binding Value}" />
-                        </Rectangle.Fill>
-                    </Rectangle>
+                               StrokeThickness="1" />
 
                     <controls:EditTextBox Grid.Column="1"
                                           Height="Auto"
@@ -507,13 +501,11 @@
                        Foreground="{DynamicResource Snoop.Brushes.Default.Foreground}"
                        Text="{Binding ColorText}" />
             <Border Grid.Column="2"
-                    HorizontalAlignment="Stretch"
-                    VerticalAlignment="Stretch"
+                    Background="{Binding Color, Converter={x:Static converters:ColorToSolidColorBrushConverter.DefaultInstance}}"
                     BorderBrush="{DynamicResource Snoop.Brushes.Default.ControlDark}"
-                    BorderThickness="1">
-                <Border.Background>
-                    <SolidColorBrush Color="{Binding Color}" />
-                </Border.Background>
+                    BorderThickness="1"
+                    HorizontalAlignment="Stretch"
+                    VerticalAlignment="Stretch">
             </Border>
         </Grid>
     </DataTemplate>

--- a/Snoop.Core/Converters/ColorToSolidColorBrushConverter.cs
+++ b/Snoop.Core/Converters/ColorToSolidColorBrushConverter.cs
@@ -1,0 +1,35 @@
+﻿namespace Snoop.Converters;
+
+using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+using System.Windows.Media;
+
+[ValueConversion(typeof(Color), typeof(SolidColorBrush))]
+public sealed class ColorToSolidColorBrushConverter : IValueConverter
+{
+  public static ColorToSolidColorBrushConverter DefaultInstance { get; } = new();
+
+  public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value is not Color color)
+        {
+            return DependencyProperty.UnsetValue;
+        }
+
+        var brush = new SolidColorBrush(color);
+        brush.Freeze();
+        return brush;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value is not SolidColorBrush brush)
+        {
+            return DependencyProperty.UnsetValue;
+        }
+
+        return brush.Color;
+    }
+}


### PR DESCRIPTION
Hey,
we noticed that we are getting binding errors everytime we attach Snoop to our application.

> System.Windows.Data Error: 2 : Cannot find governing FrameworkElement or FrameworkContentElement for target element. BindingExpression:Path=Color; DataItem=null; target element is 'SolidColorBrush' (HashCode=31748810); target property is 'Color' (type 'Color')

I first thought it might be one of our bindings but couldn't find one where we bind to the mentioned path. I finally had some time to do some research and checked the source code of Snoop if there is such a binding.

I've added a converter to convert a Color to a SolidColorBrush and that fixed it.

Let me know if you want any changes.