### PR TITLE
Better target windows titles

### DIFF
--- a/Snoop/WindowInfo.cs
+++ b/Snoop/WindowInfo.cs
@@ -178,7 +178,7 @@ public class WindowInfo
         {
             var windowTitle = NativeMethods.GetText(this.HWnd);
 
-            if (string.IsNullOrEmpty(windowTitle))
+            if (string.IsNullOrEmpty(windowTitle) || windowTitle == "CiceroUIWndFrame")
             {
                 try
                 {


### PR DESCRIPTION
Most of the target windows in the list say "CiceroUIWndFrame" for title, which is unhelpful when there is multiple instances of the process.

Before:
![image](https://github.com/snoopwpf/snoopwpf/assets/10546952/62eff11e-a1d3-4a80-8397-8365c47b198f)

After:
![image](https://github.com/snoopwpf/snoopwpf/assets/10546952/77e1d2cb-f165-4a04-9c67-a3c19f985b9f)