### PR TITLE
Fix Indent binding error on TreeViewItem

### DIFF
--- a/Snoop.Core/Controls/ProperTreeView.cs
+++ b/Snoop.Core/Controls/ProperTreeView.cs
@@ -156,16 +156,34 @@ public class ProperTreeViewItem : TreeViewItem
 
     public double Indent
     {
-        get => (double)this.GetValue(IndentProperty);
-        set => this.SetValue(IndentProperty, value);
+        get => GetIndent(this);
+        set => SetIndent(this, value);
     }
 
-    /// <summary>Identifies the <see cref="Indent"/> dependency property.</summary>
+    /// <summary>
+    ///   Identifies the <see cref="Indent" /> attached dependency property.
+    /// </summary>
     public static readonly DependencyProperty IndentProperty =
-        DependencyProperty.Register(
+        DependencyProperty.RegisterAttached(
             nameof(Indent),
             typeof(double),
             typeof(ProperTreeViewItem));
+
+    /// <summary>
+    ///   Sets the <see cref="Indent" /> property value on the target element.
+    /// </summary>
+    public static void SetIndent(DependencyObject element, double value)
+    {
+        element.SetValue(IndentProperty, value);
+    }
+
+    /// <summary>
+    ///   Gets the <see cref="Indent"/> property value of the target element.
+    /// </summary>
+    public static double GetIndent(DependencyObject element)
+    {
+        return (double)element.GetValue(IndentProperty);
+    }
 
     protected override DependencyObject GetContainerForItemOverride()
     {

--- a/Snoop.Core/Styles.xaml
+++ b/Snoop.Core/Styles.xaml
@@ -236,7 +236,7 @@
                                 Background="{TemplateBinding Background}"
                                 BorderBrush="{TemplateBinding BorderBrush}"
                                 BorderThickness="{TemplateBinding BorderThickness}">
-                            <StackPanel Margin="{Binding Indent, Converter={StaticResource IndentToMarginConverter}, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:ProperTreeViewItem}}}"
+                            <StackPanel Margin="{TemplateBinding controls:ProperTreeViewItem.Indent, Converter={StaticResource IndentToMarginConverter}}"
                                         Orientation="Horizontal">
                                 <ToggleButton x:Name="Expander"
                                               Style="{StaticResource TreeViewToggleStyle}"


### PR DESCRIPTION
Hey batzen,
I've found another binding error in the events tab. 

> System.Windows.Data Error: 4 : Cannot find source for binding with reference 'RelativeSource FindAncestor, AncestorType='Snoop.Controls.ProperTreeViewItem', AncestorLevel='1''. BindingExpression:Path=Indent; DataItem=null; target element is 'StackPanel' (Name=''); target property is 'Margin' (type 'Thickness')

The problem was that the binding explicitly searched for a ProperTreeViewItem but the "ProperTreeViewItemStyle" style was used with a standard TreeViewItem so it could not find a suitable element.

I've changed the property to an attached dependency property and the binding to a TemplateBinding. That means if the Property is not set on the TemplateParent it should be using the default value of 0.

Greetings 
Philipp

PS: There also seems to be two possible binding errors with the Vertical- and HorizontalContentAlignments of that style. But I only run into them while using Snoop on the Snoop window itself, not during the normal "snooping" of an application