### PR TITLE
Add option to ignore non hit test visible elements

### DIFF
--- a/Snoop.Core/Windows/SnoopUI.xaml
+++ b/Snoop.Core/Windows/SnoopUI.xaml
@@ -147,7 +147,7 @@
                               IsCheckable="True"
                               IsChecked="{Binding IsHandlingCTRL_SHIFT}"
                               ToolTip="When enabled and pressed tracks all parts of the UI." />
-                    <MenuItem Header="CTRL + Shift selects hit test invisible"
+                    <MenuItem Header="CTRL + SHIFT selects hit test invisible"
                               IsEnabled="{Binding ElementName=CtrlShiftMenuItem, Path=IsChecked}"
                               IsCheckable="True"
                               IsChecked="{Binding IgnoreHitTestVisibility}"

--- a/Snoop.Core/Windows/SnoopUI.xaml
+++ b/Snoop.Core/Windows/SnoopUI.xaml
@@ -142,10 +142,16 @@
                               IsCheckable="True"
                               IsChecked="{Binding SkipTemplateParts}"
                               ToolTip="When enabled and pressed tries to skip template parts." />
-                    <MenuItem Header="Handle CTRL + _SHIFT"
+                    <MenuItem x:Name="CtrlShiftMenuItem"
+                              Header="Handle CTRL + _SHIFT"
                               IsCheckable="True"
                               IsChecked="{Binding IsHandlingCTRL_SHIFT}"
                               ToolTip="When enabled and pressed tracks all parts of the UI." />
+                    <MenuItem Header="CTRL + Shift selects hit test invisible"
+                              IsEnabled="{Binding ElementName=CtrlShiftMenuItem, Path=IsChecked}"
+                              IsCheckable="True"
+                              IsChecked="{Binding IgnoreHitTestVisibility}"
+                              ToolTip="When this is enabled, CTRL + SHIFT also selects UI elements that have IsHitTestVisible=false" />
                     <Separator />
                     <MenuItem Header="Highlight selected item"
                               IsCheckable="True"

--- a/Snoop.Core/Windows/SnoopUI.xaml.cs
+++ b/Snoop.Core/Windows/SnoopUI.xaml.cs
@@ -320,6 +320,8 @@ public sealed partial class SnoopUI : INotifyPropertyChanged
     // ReSharper disable once InconsistentNaming
     public bool IsHandlingCTRL_SHIFT { get; set; } = true;
 
+    public bool IgnoreHitTestVisibility { get; set; } = true;
+
     // ReSharper disable once InconsistentNaming
     public bool SkipTemplateParts { get; set; } = false;
 
@@ -651,7 +653,7 @@ public sealed partial class SnoopUI : INotifyPropertyChanged
             return;
         }
 
-        var itemToFind = Mouse.PrimaryDevice.GetDirectlyOver();
+        var itemToFind = Mouse.PrimaryDevice.GetDirectlyOver(this.IgnoreHitTestVisibility);
 
         switch (itemToFind)
         {


### PR DESCRIPTION
implements #467 

Added a new Tracking option named 'CTRL + SHIFT selects hit test invisible' (active by default to mimic the current behavior). I am happy about suggestions for a better description of this option.
When this option is disabled, elements with `IsHitTestVisible=false` will be skipped in the hit test filter.